### PR TITLE
Fix two issues with very narrow displays.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -141,6 +141,7 @@
 	padding: 20px;
 	color: #666;
 	font-size: 32px;
+	line-height: normal;
 }
 
 .msg-sent, .msg-recv {
@@ -200,7 +201,9 @@
 .ocsms-plavatar, .ocsms-plavatar-big {
 	display: inline-block;
 	height: 40px;
+	min-height: 40px;
 	width: 40px;
+	min-width: 40px;
 	line-height: 40px;
 	border-radius: 50%;
 	vertical-align: middle;
@@ -214,7 +217,9 @@
 
 .ocsms-plavatar-big {
 	height: 75px;
+	min-height: 75px;
 	width: 75px;
+	min-width: 75px;
 	line-height: 55px;
 }
 


### PR DESCRIPTION
First a contact that uses just the first initial would become "squished" instead of being round.
Second the "Please choose a conversation on the left menu" text would overlap itself if it wrapped around to a second line.